### PR TITLE
Store original set names when collapsing redundant sets

### DIFF
--- a/gsea_api/molecular_signatures_db.py
+++ b/gsea_api/molecular_signatures_db.py
@@ -155,7 +155,10 @@ class GeneSets:
                         if len(names) > collapse_limit else
                         ''
                     ),
-                    description=collapse_redundant.join(names)
+                    description=collapse_redundant.join(names),
+                    metadata={
+                        'original_gene_set_names': names
+                    }
                 )
                 for frozen_genes, names in redundant.items()
             ]


### PR DESCRIPTION
Allows to retrieve the original sets using metadata