### PR TITLE
add species in gmt file name

### DIFF
--- a/gsea_api/molecular_signatures_db.py
+++ b/gsea_api/molecular_signatures_db.py
@@ -411,17 +411,23 @@ class MolecularSignaturesDatabase:
             gene_set.metadata = metadata_by_name[gene_set.name]
 
     def parse_name(self, name):
-        parsed = re.match(rf'(?P<name>.*?)\.v{self.version}\.(?P<species>.*?)\.(?P<id_type>(entrez|symbols)).gmt', name)
+        if int(float(self.version)) >= 2022: # 'Hs' is included in gmt filename after 2022 version
+            parsed = re.match(rf'(?P<name>.*?)\.v{self.version}\.(?P<species>.*?)\.(?P<id_type>(entrez|symbols)).gmt', name)
+        else:
+            parsed= re.match(rf'(?P<name>.*?)\.v{self.version}\.(?P<id_type>(entrez|symbols)).gmt', name)
         return parsed.groupdict()
 
     def resolve(self, gene_sets, species, id_type) -> Path:
-        path = self.path / f'{gene_sets}.v{self.version}.{species}.{id_type}.gmt'
+        if int(float(self.version)) >= 2022: # 'Hs' is included in gmt filename after 2022 version
+            path = self.path / f'{gene_sets}.v{self.version}.{species}.{id_type}.gmt'
+        else:
+            path = self.path / f'{gene_sets}.v{self.version}.{id_type}.gmt'
         if path.exists():
             return path
         else:
             raise ValueError(f'Unknown library: {path}!')
 
-    def load(self, gene_sets: str, species: str, id_type: str) -> GeneSets:
+    def load(self, gene_sets: str, species: str='Hs', id_type: str) -> GeneSets:
         path = self.resolve(gene_sets=gene_sets, species=species, id_type=id_type)
 
         gene_sets = GeneSets.from_gmt(path, name=gene_sets)

--- a/gsea_api/molecular_signatures_db.py
+++ b/gsea_api/molecular_signatures_db.py
@@ -411,18 +411,18 @@ class MolecularSignaturesDatabase:
             gene_set.metadata = metadata_by_name[gene_set.name]
 
     def parse_name(self, name):
-        parsed = re.match(rf'(?P<name>.*?)\.v{self.version}\.(?P<id_type>(entrez|symbols)).gmt', name)
+        parsed = re.match(rf'(?P<name>.*?)\.v{self.version}\.(?P<species>.*?)\.(?P<id_type>(entrez|symbols)).gmt', name)
         return parsed.groupdict()
 
-    def resolve(self, gene_sets, id_type) -> Path:
-        path = self.path / f'{gene_sets}.v{self.version}.{id_type}.gmt'
+    def resolve(self, gene_sets, species, id_type) -> Path:
+        path = self.path / f'{gene_sets}.v{self.version}.{species}.{id_type}.gmt'
         if path.exists():
             return path
         else:
             raise ValueError(f'Unknown library: {path}!')
 
-    def load(self, gene_sets: str, id_type: str) -> GeneSets:
-        path = self.resolve(gene_sets=gene_sets, id_type=id_type)
+    def load(self, gene_sets: str, species: str, id_type: str) -> GeneSets:
+        path = self.resolve(gene_sets=gene_sets, species=species, id_type=id_type)
 
         gene_sets = GeneSets.from_gmt(path, name=gene_sets)
     

--- a/gsea_api/molecular_signatures_db.py
+++ b/gsea_api/molecular_signatures_db.py
@@ -427,7 +427,7 @@ class MolecularSignaturesDatabase:
         else:
             raise ValueError(f'Unknown library: {path}!')
 
-    def load(self, gene_sets: str, species: str='Hs', id_type: str) -> GeneSets:
+    def load(self, gene_sets: str, id_type: str, species: str='Hs') -> GeneSets:
         path = self.resolve(gene_sets=gene_sets, species=species, id_type=id_type)
 
         gene_sets = GeneSets.from_gmt(path, name=gene_sets)


### PR DESCRIPTION
the newer version of the gmt file includes species identifier (e.g., c3.tft.gtrd.v2023.1.Hs.symbols.gmt).
```python
def parse_name(name):
    parsed = re.match(rf'(?P<name>.*?)\.v{re.escape(version)}\.(?P<id_type>(entrez|symbols)).gmt', name)
    return parsed.groupdict()

name = 'c3.tft.gtrd.v2023.1.Hs.symbols.gmt'
version = 2023.1
parsed = re.match(rf'(?P<name>.*?)\.v{version}\.(?P<species>.*?)\.(?P<id_type>(entrez|symbols)).gmt', name)
parsed.groupdict()
```

The load and resolve have been modified to allow input of species (e.g., 'Hs')
```
msigdb = MolecularSignaturesDatabase_test(path='/home/lms/Downloads/msigdb', version=2023.1)
msigdb.gene_sets
kegg_pathways = msigdb.load('c2.cp.kegg', 'Hs', 'symbols')
```